### PR TITLE
Fixes typos which misspell initialize as intialize

### DIFF
--- a/callstats-java-sdk/src/main/java/io/callstats/sdk/CallStats.java
+++ b/callstats-java-sdk/src/main/java/io/callstats/sdk/CallStats.java
@@ -78,7 +78,7 @@ public class CallStats {
 	}
 	
 	/**
-	 * Intialize callstats.
+	 * Initialize callstats.
 	 *
 	 * @param appId the app id
 	 * @param appSecret the app secret
@@ -86,10 +86,10 @@ public class CallStats {
 	 * @param endpointInfo the endpoint info
 	 * @param callStatsInitListener the call stats init listener
 	 */
-	public void intialize(final int appId, final String appSecret, final String bridgeId, final EndpointInfo endpointInfo, final CallStatsInitListener callStatsInitListener) {
+	public void initialize(final int appId, final String appSecret, final String bridgeId, final EndpointInfo endpointInfo, final CallStatsInitListener callStatsInitListener) {
 		if (appId <= 0 || StringUtils.isBlank(appSecret) || StringUtils.isBlank(bridgeId) || endpointInfo == null || callStatsInitListener == null) {
-			logger.error("intialize: Arguments cannot be null ");
-			throw new IllegalArgumentException("intialize: Arguments cannot be null");
+			logger.error("initialize: Arguments cannot be null ");
+			throw new IllegalArgumentException("initialize: Arguments cannot be null");
 		}
 		
 		this.appId = appId;

--- a/callstats-java-sdk/src/test/java/io/callstats/sdk/CallStatsTest.java
+++ b/callstats-java-sdk/src/test/java/io/callstats/sdk/CallStatsTest.java
@@ -46,11 +46,11 @@ public class CallStatsTest{
 	}
 	
 	/**
-	 * Intialize test.
+	 * Initialize test.
 	 */
 	@Test
-	public void intializeTest() {
-		callstatslib.intialize(497346896, appSecret, "jit.si.345",endpointInfo,listener);
+	public void initializeTest() {
+		callstatslib.initialize(497346896, appSecret, "jit.si.345",endpointInfo,listener);
 		try {
 			Thread.sleep(5000);
 		} catch (InterruptedException e) {
@@ -62,13 +62,13 @@ public class CallStatsTest{
 	}
 	
 	/**
-	 * Intialize with invalid app id test.
+	 * Initialize with invalid app id test.
 	 */
 	@Test
-	public void intializeWithInvalidAppIdTest() {
+	public void initializeWithInvalidAppIdTest() {
 		CallStatsErrors error = CallStatsErrors.HTTP_ERROR;
 		String errMsg = "SDK Authentication Error";
-		callstatslib.intialize(175240363, appSecret, "jit.si.345",endpointInfo,listener);
+		callstatslib.initialize(175240363, appSecret, "jit.si.345",endpointInfo,listener);
 		try {
 			Thread.sleep(2000);
 		} catch (InterruptedException e) {
@@ -79,42 +79,42 @@ public class CallStatsTest{
 	}
 	
 	/**
-	 * Intialize with null args test.
+	 * Initialize with null args test.
 	 */
 	@Test
-	public void intializeWithNullArgsTest() {
+	public void initializeWithNullArgsTest() {
 		Throwable e = null;
 
 		try {
-		callstatslib.intialize(0, appSecret, "jit.si.345",endpointInfo,listener);
+		callstatslib.initialize(0, appSecret, "jit.si.345",endpointInfo,listener);
 		} catch (Throwable e1) {
 			e = e1;
 		}
 		assertTrue(e instanceof IllegalArgumentException);
 		
 		try {
-			callstatslib.intialize(175240363, null, "jit.si.345",endpointInfo,listener);
+			callstatslib.initialize(175240363, null, "jit.si.345",endpointInfo,listener);
 		} catch (Throwable e1) {
 				e = e1;
 		}
 		assertTrue(e instanceof IllegalArgumentException);
 		
 		try {
-			callstatslib.intialize(175240363, appSecret, null,endpointInfo,listener);
+			callstatslib.initialize(175240363, appSecret, null,endpointInfo,listener);
 		} catch (Throwable e1) {
 				e = e1;
 		}
 		assertTrue(e instanceof IllegalArgumentException);
 		
 		try {
-			callstatslib.intialize(175240363, "", "jit.si.345",endpointInfo,listener);
+			callstatslib.initialize(175240363, "", "jit.si.345",endpointInfo,listener);
 		} catch (Throwable e1) {
 				e = e1;
 		}
 		assertTrue(e instanceof IllegalArgumentException);
 		
 		try {
-			callstatslib.intialize(175240363, appSecret, "",endpointInfo,listener);
+			callstatslib.initialize(175240363, appSecret, "",endpointInfo,listener);
 		} catch (Throwable e1) {
 				e = e1;
 		}
@@ -124,11 +124,11 @@ public class CallStatsTest{
 	
 	
 	/**
-	 * Intialize test with send call stats event.
+	 * Initialize test with send call stats event.
 	 */
 	@Test
-	public void intializeTestWithSendCallStatsEvent() {
-		callstatslib.intialize(497346896, appSecret, "jit.si.345",endpointInfo,listener);
+	public void initializeTestWithSendCallStatsEvent() {
+		callstatslib.initialize(497346896, appSecret, "jit.si.345",endpointInfo,listener);
 		try {
 			Thread.sleep(2000);
 		} catch (InterruptedException e) {


### PR DESCRIPTION
The most notable is the CallStats#intialize() method name (and its javadoc and log messages). Respectively, the same typo is present in the unit test method names (and their javadocs).